### PR TITLE
lang: support CSV and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,11 @@ If `emdo` and `emdone` magic comments were used, it will only embed the code
 block wrapped by the magic comments.
 
 It is aware of code comment styles for Ada, Assembly, Awk, Bash, C, Clojure,
-COBOL, C++, C#, CSS, D, Dart, Elm, Erlang, Elixir, Fortran, F#, Gleam, Go, Haml,
-Haskell, HTML, Java, Julia, JavaScript, JSX, Kotlin, Lisp, Logo, Lua, MATLAB,
-OCaml, Objective-C, Mojo, Nim, Pascal, PHP, Perl, Prolog, Python, R, Ruby, Rust,
-Scala, Scheme, Sass, Shell, Solidity, SQL, Swift, Tcl, TypeScript, TSX,
-VBScript, Visual Basic, Wolfram, YAML, and Zig.
+COBOL, C++, C#, CSS, CSV, D, Dart, Elm, Erlang, Elixir, Fortran, F#, Gleam, Go,
+Haml, Haskell, HTML, Java, Julia, JavaScript, JSON, JSX, Kotlin, Lisp, Logo,
+Lua, MATLAB, OCaml, Objective-C, Mojo, Nim, Pascal, PHP, Perl, Prolog, Python,
+R, Ruby, Rust, Scala, Scheme, Sass, Shell, Solidity, SQL, Swift, Tcl,
+TypeScript, TSX, VBScript, Visual Basic, Wolfram, YAML, and Zig.
 
 If you reference another Markdown file, `mdembed` will embed its contents
 directly, recursively embedding its code blocks.

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var styles = map[string]Style{
 	".cpp":   {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // C++
 	".cs":    {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // C#
 	".css":   {BlockDo: "/*", BlockDone: "*/"},                      // CSS
+	".csv":   {NoComment: true},                                     // CSV
 	".d":     {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // D
 	".dart":  {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // Dart
 	".elm":   {LineComment: "--", BlockDo: "{-", BlockDone: "-}"},   // Elm
@@ -39,6 +40,7 @@ var styles = map[string]Style{
 	".java":  {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // Java
 	".jl":    {LineComment: "#", BlockDo: "#=", BlockDone: "=#"},    // Julia
 	".js":    {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // JavaScript
+	".json":  {NoComment: true},                                     // JSON
 	".jsx":   {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // JSX
 	".kt":    {LineComment: "//", BlockDo: "/*", BlockDone: "*/"},   // Kotlin
 	".lisp":  {LineComment: ";", BlockDo: "#|", BlockDone: "|#"},    // Lisp
@@ -82,6 +84,7 @@ type Style struct {
 	LineComment string
 	BlockDo     string
 	BlockDone   string
+	NoComment   bool
 }
 
 func main() {
@@ -251,6 +254,14 @@ func processCodeFile(filename, blockName, fileContent string, output io.Writer) 
 		fileName = style.LineComment + " " + filename
 	} else if style.BlockDo != "" && style.BlockDone != "" {
 		fileName = fmt.Sprintf("%s %s %s", style.BlockDo, filename, style.BlockDone)
+	} else {
+		// For file types without comments (like JSON), just use the filename
+		fileName = filename
+	}
+
+	// If a block name is specified and the file doesn't support comments, return an error
+	if blockName != "" && style.NoComment {
+		return fmt.Errorf("block embedding is not supported for files that do not support comments, such as %s", filename)
 	}
 
 	// If a block name is specified, extract block between marks
@@ -295,6 +306,7 @@ func getBlockMarkers(style Style, blockName string) (string, string) {
 		doMark = fmt.Sprintf("%s %s %s", style.BlockDo, beginContent, style.BlockDone)
 		doneMark = fmt.Sprintf("%s %s %s", style.BlockDo, endContent, style.BlockDone)
 	} else {
+		// For files without comments, return empty markers
 		return "", ""
 	}
 


### PR DESCRIPTION
Add support for text-based file formats that don't have comments.
