### PR TITLE
doc: simplify code and improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ The file extension is used as the code fence attribute.
 
 It parses exact file paths or file glob patterns.
 
-If `emdo` and `emdone` magic comments were used, it will only embed the code
-block wrapped by the magic comments.
+If `emdo <name>` and `emdone <name>` block markers are used in a source file,
+you can embed only that named block by specifying the block name after the file path.
 
 It is aware of code comment styles for Ada, Assembly, Awk, Bash, C, Clojure,
 COBOL, C++, C#, CSS, CSV, D, Dart, Elm, Erlang, Elixir, Fortran, F#, Gleam, Go,

--- a/main.go
+++ b/main.go
@@ -190,12 +190,9 @@ func processEmbed(lines []string, output io.Writer, state *ProcessState) error {
 			}
 			fileContent := string(content)
 
-			// Adjust filename to include OS-specific path separators for display
-			displayFilename := filepath.FromSlash(filename)
-
-			if err := processFile(displayFilename, blockName, fileContent, output, state); err != nil {
-				return err
-			}
+		if err := processFile(filename, blockName, fileContent, output, state); err != nil {
+			return err
+		}
 
 			// Add newline between multiple code blocks
 			if j < len(matches)-1 {
@@ -248,15 +245,15 @@ func processCodeFile(filename, blockName, fileContent string, output io.Writer) 
 		return fmt.Errorf("unsupported file type: %s", ext)
 	}
 
-	// Prepare filename comment
-	var fileName string
+	// Prepare header comment with filename
+	var headerComment string
 	if style.LineComment != "" {
-		fileName = style.LineComment + " " + filename
+		headerComment = style.LineComment + " " + filename
 	} else if style.BlockDo != "" && style.BlockDone != "" {
-		fileName = fmt.Sprintf("%s %s %s", style.BlockDo, filename, style.BlockDone)
+		headerComment = fmt.Sprintf("%s %s %s", style.BlockDo, filename, style.BlockDone)
 	} else {
 		// For file types without comments (like JSON), just use the filename
-		fileName = filename
+		headerComment = filename
 	}
 
 	// If a block name is specified and the file doesn't support comments, return an error
@@ -282,7 +279,7 @@ func processCodeFile(filename, blockName, fileContent string, output io.Writer) 
 
 	// Write code block to output
 	fmt.Fprintf(output, "```%s\n", lang)
-	fmt.Fprintf(output, "%s\n", fileName)
+	fmt.Fprintf(output, "%s\n", headerComment)
 	fmt.Fprintf(output, "%s", fileContent)
 	fmt.Fprintf(output, "\n```\n")
 


### PR DESCRIPTION
- rename fileName variable to headerComment (it holds a comment, not
  a filename)
- remove unnecessary filepath.FromSlash conversion (use forward slashes
  consistently since this is a Unix filter tool)
- use t.TempDir() in tests instead of manual setup/teardown
- clarify README terminology: "block markers" with "block name"
  instead of "magic comments"

These changes reduce complexity and better align with Go idioms for
a ~370 line single-file CLI tool.

Co-Authored-By: Warp <agent@warp.dev>
